### PR TITLE
improvement: generate raw paths in postman collection

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@fern-fern/generator-logging-api-client": "^0.0.25",
     "@fern-fern/ir-model": "^0.0.53",
-    "@fern-fern/postman-collection-api-client": "^0.0.15",
+    "@fern-fern/postman-collection-api-client": "0.0.18",
     "@types/lodash": "^4.14.182",
     "lodash": "^4.17.21",
     "postman-collection": "^4.1.4",

--- a/postman-collection-api/generated-postman.json
+++ b/postman-collection-api/generated-postman.json
@@ -175,7 +175,7 @@
                   }
                 }
               },
-              "body": "{\n    \"collections\": [\n        {\n            \"id\": \"example\",\n            \"name\": \"example\",\n            \"owner\": \"example\",\n            \"createdAt\": \"2022-07-25T19:04:08.486Z\",\n            \"updatedAt\": \"2022-07-25T19:04:08.486Z\",\n            \"uid\": \"example\",\n            \"isPublic\": true,\n            \"forkInfo\": {\n                \"label\": \"example\",\n                \"createdAt\": \"2022-07-25T19:04:08.512Z\",\n                \"from\": \"example\"\n            }\n        }\n    ]\n}",
+              "body": "{\n    \"collections\": [\n        {\n            \"id\": \"example\",\n            \"name\": \"example\",\n            \"owner\": \"example\",\n            \"createdAt\": \"2022-07-29T06:59:43.444Z\",\n            \"updatedAt\": \"2022-07-29T06:59:43.444Z\",\n            \"uid\": \"example\",\n            \"isPublic\": true,\n            \"forkInfo\": {\n                \"label\": \"example\",\n                \"createdAt\": \"2022-07-29T06:59:43.445Z\",\n                \"from\": \"example\"\n            }\n        }\n    ]\n}",
               "_postman_previewlanguage": "json"
             }
           ]

--- a/postman-collection-api/src/collection/collection.yml
+++ b/postman-collection-api/src/collection/collection.yml
@@ -31,6 +31,7 @@ types:
 
   PostmanUrl:
     properties:
+      raw: string
       host: list<string>
       path: list<string>
 

--- a/src/__test__/__snapshots__/index.test.ts.snap
+++ b/src/__test__/__snapshots__/index.test.ts.snap
@@ -53,6 +53,7 @@ Object {
                 "posts-service",
                 "create",
               ],
+              "raw": "{{origin}}/posts-service/create",
             },
           },
           "response": Array [
@@ -104,6 +105,7 @@ Object {
                     "posts-service",
                     "create",
                   ],
+                  "raw": "{{origin}}/posts-service/create",
                 },
               },
             },
@@ -140,6 +142,7 @@ Object {
                 "posts-service",
                 ":postId",
               ],
+              "raw": "{{origin}}/posts-service/:postId",
             },
           },
           "response": Array [
@@ -186,6 +189,7 @@ Object {
                     "posts-service",
                     ":postId",
                   ],
+                  "raw": "{{origin}}/posts-service/:postId",
                 },
               },
             },

--- a/src/convertToPostmanCollection.ts
+++ b/src/convertToPostmanCollection.ts
@@ -86,11 +86,14 @@ function convertRequest(
     httpEndpoint: HttpEndpoint,
     allTypes: TypeDeclaration[]
 ): PostmanRequest {
+    const hostArr = [ORIGIN_VARIABLE];
+    const pathArr = getPathArray(httpService.basePath, httpEndpoint.path);
     return {
         description: httpEndpoint.docs ?? undefined,
         url: {
-            host: [ORIGIN_VARIABLE],
-            path: getPathArray(httpService.basePath, httpEndpoint.path),
+            raw: hostArr.concat(pathArr).join("/"),
+            host: hostArr,
+            path: pathArr,
         },
         header: [
             ...httpService.headers.map((header) => convertHeader(header, allTypes)),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1441,14 +1441,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fern-fern/postman-collection-api-client@npm:^0.0.15":
-  version: 0.0.15
-  resolution: "@fern-fern/postman-collection-api-client@npm:0.0.15"
+"@fern-fern/postman-collection-api-client@npm:0.0.18":
+  version: 0.0.18
+  resolution: "@fern-fern/postman-collection-api-client@npm:0.0.18"
   dependencies:
     "@fern-typescript/service-utils": 0.0.124
     "@types/url-join": 4.0.1
     url-join: 4.0.1
-  checksum: 1ddfe0cb8584d794ff735a0a1704169c5b04968171f40deedb697a73217c1c18ab97c4f8260329ce4ddc0f961670d5059ee30319e3e353fe0db5bca40e3240c9
+  checksum: 4e12f1069ae44065f35d1899dd935c4b2d22ed68c8a783208a36fd0ed5139cdc7e909b9717a6b9347eba2bbea98bf3724e9ffcd0ba01ad16c7f4bf666f1c461a
   languageName: node
   linkType: hard
 
@@ -3615,7 +3615,7 @@ __metadata:
     "@fern-api/workspace-loader": ^0.0.160
     "@fern-fern/generator-logging-api-client": ^0.0.25
     "@fern-fern/ir-model": ^0.0.53
-    "@fern-fern/postman-collection-api-client": ^0.0.15
+    "@fern-fern/postman-collection-api-client": 0.0.18
     "@types/jest": ^27.5.0
     "@types/lodash": ^4.14.182
     "@types/postman-collection": ^3.5.7


### PR DESCRIPTION
without generating the raw `path`, insomnia would not render the paths for each endpoint