### PR TITLE
fix: top level api docs are added to postman collection

### DIFF
--- a/fern/postman/definition/api.yml
+++ b/fern/postman/definition/api.yml
@@ -1,5 +1,9 @@
 name: postman
 auth: api-key
+docs: |
+  These are my docs.
+  ## Welcome to my title
+  More docs with [links](http://localhost.com)
 auth-schemes:
   api-key:
     header: X-API-KEY

--- a/fern/postman/definition/api.yml
+++ b/fern/postman/definition/api.yml
@@ -1,9 +1,5 @@
 name: postman
 auth: api-key
-docs: |
-  These are my docs.
-  ## Welcome to my title
-  More docs with [links](http://localhost.com)
 auth-schemes:
   api-key:
     header: X-API-KEY

--- a/fern/postman/definition/collection.yml
+++ b/fern/postman/definition/collection.yml
@@ -22,6 +22,7 @@ types:
     properties:
       name: string
       schema: string
+      description: optional<string>
 
   PostmanCollectionItem:
     discriminant:

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@fern-api/config-management-commons": "0.0.188-13-g68e2f408",
     "@fern-fern/generator-exec-sdk": "^0.0.42",
     "@fern-fern/ir-model": "0.0.1165",
-    "@fern-fern/postman-sdk": "0.0.39",
+    "@fern-fern/postman-sdk": "0.0.46",
     "@types/lodash": "^4.14.182",
     "endent": "^2.1.0",
     "lodash": "^4.17.21",

--- a/src/__test__/__snapshots__/convertToPostmanCollection.test.ts.snap
+++ b/src/__test__/__snapshots__/convertToPostmanCollection.test.ts.snap
@@ -243,7 +243,7 @@ exports[`convertToPostman test-api 1`] = `
   \\"info\\": {
     \\"name\\": \\"Blog Post API\\",
     \\"schema\\": \\"https://schema.getpostman.com/json/collection/v2.1.0/collection.json\\",
-    \\"description\\": null
+    \\"description\\": \\"These are my docs.\\\\n## Welcome to my title\\\\nMore docs with [links](http://localhost.com)\\\\n\\"
   },
   \\"variable\\": [
     {

--- a/src/__test__/__snapshots__/convertToPostmanCollection.test.ts.snap
+++ b/src/__test__/__snapshots__/convertToPostmanCollection.test.ts.snap
@@ -4,7 +4,8 @@ exports[`convertToPostman any-auth 1`] = `
 "{
   \\"info\\": {
     \\"name\\": \\"Any Auth\\",
-    \\"schema\\": \\"https://schema.getpostman.com/json/collection/v2.1.0/collection.json\\"
+    \\"schema\\": \\"https://schema.getpostman.com/json/collection/v2.1.0/collection.json\\",
+    \\"description\\": null
   },
   \\"variable\\": [
     {
@@ -133,7 +134,8 @@ exports[`convertToPostman loop-test-api 1`] = `
 "{
   \\"info\\": {
     \\"name\\": \\"Loop API\\",
-    \\"schema\\": \\"https://schema.getpostman.com/json/collection/v2.1.0/collection.json\\"
+    \\"schema\\": \\"https://schema.getpostman.com/json/collection/v2.1.0/collection.json\\",
+    \\"description\\": null
   },
   \\"variable\\": [
     {
@@ -240,7 +242,8 @@ exports[`convertToPostman test-api 1`] = `
 "{
   \\"info\\": {
     \\"name\\": \\"Blog Post API\\",
-    \\"schema\\": \\"https://schema.getpostman.com/json/collection/v2.1.0/collection.json\\"
+    \\"schema\\": \\"https://schema.getpostman.com/json/collection/v2.1.0/collection.json\\",
+    \\"description\\": null
   },
   \\"variable\\": [
     {

--- a/src/__test__/fixtures/fern/test-api/definition/api.yml
+++ b/src/__test__/fixtures/fern/test-api/definition/api.yml
@@ -1,6 +1,10 @@
 name: blog-post-api
 display-name: Blog Post API
 auth: apiKey
+docs: |
+  These are my docs.
+  ## Welcome to my title
+  More docs with [links](http://localhost.com)
 auth-schemes:
   apiKey:
     header: X-API-Key

--- a/src/convertToPostmanCollection.ts
+++ b/src/convertToPostmanCollection.ts
@@ -26,6 +26,7 @@ export function convertToPostmanCollection(ir: IntermediateRepresentation): Post
         info: {
             name: ir.apiDisplayName ?? startCase(id.originalName),
             schema: "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+            description: ir.apiDocs ?? undefined,
         },
         variable: [
             {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1378,14 +1378,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fern-fern/postman-sdk@npm:0.0.39":
-  version: 0.0.39
-  resolution: "@fern-fern/postman-sdk@npm:0.0.39"
+"@fern-fern/postman-sdk@npm:0.0.46":
+  version: 0.0.46
+  resolution: "@fern-fern/postman-sdk@npm:0.0.46"
   dependencies:
     "@types/url-join": 4.0.1
     axios: 0.27.2
     url-join: 4.0.1
-  checksum: 7bfad8fa00ae1707a37b40164c3b8bf4752a8d7ab0ce3427fc00d079a449ac3f7970201e3e8ec4d9b4fca243f4cc1a992b27771b62c6f26272ffcb44f0238bc5
+  checksum: 6031648c9c26599c2018de51ffaff024f18ae03f524ba4d77c1c83ad032cf7d0f95f1e39aef93f11620f2af8a8a890e2da6b301b7b716607757eeb3dbec8a7fd
   languageName: node
   linkType: hard
 
@@ -3776,7 +3776,7 @@ __metadata:
     "@fern-api/config-management-commons": 0.0.188-13-g68e2f408
     "@fern-fern/generator-exec-sdk": ^0.0.42
     "@fern-fern/ir-model": 0.0.1165
-    "@fern-fern/postman-sdk": 0.0.39
+    "@fern-fern/postman-sdk": 0.0.46
     "@types/jest": ^27.5.0
     "@types/lodash": ^4.14.182
     "@types/postman-collection": ^3.5.7


### PR DESCRIPTION
If one specifies docs in `api.yml` then those will be used for the Postman Collection description.